### PR TITLE
refactor: Remove flag URL parsing from QuestionDto

### DIFF
--- a/data/src/main/java/studio/astroturf/quizzi/data/remote/websocket/model/QuestionDto.kt
+++ b/data/src/main/java/studio/astroturf/quizzi/data/remote/websocket/model/QuestionDto.kt
@@ -5,21 +5,14 @@ import studio.astroturf.quizzi.domain.model.Question
 
 @Serializable
 data class QuestionDto(
-    val imageUrl: String?,
+    val imageCode: String?,
     val content: String,
     val options: List<OptionDto>,
 ) {
     fun toDomain() =
         Question(
-            countryCode = imageUrl?.let { extractCountryCode(imageUrl) },
+            countryCode = imageCode,
             content = content,
             options = options.map { it.toDomain() },
         )
-
-    private fun extractCountryCode(flagUrl: String): String =
-        flagUrl
-            .split("/")
-            .last()
-            .split(".")
-            .first()
 }


### PR DESCRIPTION
Removed the logic for parsing country codes from flag URLs within the QuestionDto, simplifying the data transfer object. The country code is now directly represented by `imageCode`.

Signed-off-by: Alican Korkmaz <>